### PR TITLE
Add sentiment analysis notebook to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,4 @@ If it's not working or you have an idea/request, then open an issue [here](https
 | Name & Link | Description | Open in Colab |
 |-------------|-------------|---------------|
 | [Lemmatize documents](Lemmatize_docs.ipynb) | Take a column of texts in English and return cleaned and lemmatized version for further analysis. | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/paskn/tools-as-notebooks/blob/main/Lemmatize_docs.ipynb) |
+| [Sentiment Analysis](Sentiment_analysis.ipynb) | Perform sentiment analysis on a CSV file containing lemmatized text using a dictionary-based approach. | [![Open In Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/paskn/tools-as-notebooks/blob/main/Sentiment_analysis.ipynb) |


### PR DESCRIPTION
Update the `README.md` to include the "Sentiment Analysis" notebook in the table.

* Add a new row to the table for the "Sentiment Analysis" notebook.
* Include a description for the "Sentiment Analysis" notebook.
* Add a link to open the "Sentiment Analysis" notebook in Colab.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/paskn/tools-as-notebooks?shareId=XXXX-XXXX-XXXX-XXXX).